### PR TITLE
pluralize category "Data Structures" in cabal file

### DIFF
--- a/red-black-tree.cabal
+++ b/red-black-tree.cabal
@@ -8,7 +8,7 @@ license-file:        LICENSE
 author:              Gabriel Aumala
 maintainer:          example@example.com
 copyright:           2017 Gabriel Aumala
-category:            Data Structure
+category:            Data Structures
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10


### PR DESCRIPTION
Hi, I was just browsing Hackage and noticed that there is a [Data Structure](https://hackage.haskell.org/packages/#cat:Data%20Structure) (singular) category and a "Data Structures" (plural) category. The latter seems much more widely used. Just in the interest of cleaning things up aesthetically, I was wondering if you would mind accepting this and releasing to Hackage? Thank you :smiley_cat: 